### PR TITLE
Add distance calculation button

### DIFF
--- a/src/components/BookingStepOne.css
+++ b/src/components/BookingStepOne.css
@@ -75,6 +75,15 @@
   cursor: pointer;
 }
 
+.distance-button {
+  padding: 0.75rem;
+  background: #10b981;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
 .fade {
   opacity: 0;
   transition: opacity 0.5s ease-in-out;

--- a/src/components/BookingStepOne.js
+++ b/src/components/BookingStepOne.js
@@ -52,27 +52,30 @@ const BookingStepOne = ({ apiKey, onNext }) => {
   }, [apiKey]);
 
   useEffect(() => {
-    if (fromAddress && toAirport) {
-      if (!window.google) return;
-      const service = new window.google.maps.DistanceMatrixService();
-      service.getDistanceMatrix(
-        {
-          origins: [fromAddress],
-          destinations: [toAirport],
-          travelMode: window.google.maps.TravelMode.DRIVING,
-        },
-        (response, status) => {
-          if (status === 'OK') {
-            const distanceMeters = response.rows[0].elements[0].distance.value;
-            const km = distanceMeters / 1000;
-            setDistanceKm(km);
-          }
-        }
-      );
-    }
+    setDistanceKm(null);
     setCalculated(false);
     setPrice(null);
   }, [fromAddress, toAirport]);
+
+  const calculateDistance = () => {
+    if (!fromAddress || !toAirport) return;
+    if (!window.google) return;
+    const service = new window.google.maps.DistanceMatrixService();
+    service.getDistanceMatrix(
+      {
+        origins: [fromAddress],
+        destinations: [toAirport],
+        travelMode: window.google.maps.TravelMode.DRIVING,
+      },
+      (response, status) => {
+        if (status === 'OK') {
+          const distanceMeters = response.rows[0].elements[0].distance.value;
+          const km = distanceMeters / 1000;
+          setDistanceKm(km);
+        }
+      }
+    );
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -164,6 +167,15 @@ const BookingStepOne = ({ apiKey, onNext }) => {
             className="p-2 border border-gray-400 rounded"
           />
         </label>
+        {fromAddress && toAirport && distanceKm == null && (
+          <button
+            type="button"
+            className="distance-button"
+            onClick={calculateDistance}
+          >
+            Strecke berechnen
+          </button>
+        )}
         {distanceKm != null && (
           <div className="price-display font-semibold mt-4">Distanz: {distanceKm.toFixed(2)} km</div>
         )}


### PR DESCRIPTION
## Summary
- reset distance and price on address changes
- allow manual distance calculation via `Strecke berechnen` button
- style new distance calculation button

## Testing
- `node test_runner.js`

------
https://chatgpt.com/codex/tasks/task_e_686c0a5b6d44832cbd5ad93b5154a2c0