### PR TITLE
Refactor distance calculation logic

### DIFF
--- a/src/utils/calcLogic.js
+++ b/src/utils/calcLogic.js
@@ -1,0 +1,28 @@
+export const KILOMETER_PRICE = 1.25; // Euro per km netto
+
+export function calculateDistanceAndPrice(fromAddress, toAirport) {
+  return new Promise((resolve, reject) => {
+    if (!window.google) {
+      reject(new Error('Google Maps API not loaded'));
+      return;
+    }
+    const service = new window.google.maps.DistanceMatrixService();
+    service.getDistanceMatrix(
+      {
+        origins: [fromAddress],
+        destinations: [toAirport],
+        travelMode: window.google.maps.TravelMode.DRIVING,
+      },
+      (response, status) => {
+        if (status === 'OK') {
+          const distanceMeters = response.rows[0].elements[0].distance.value;
+          const km = distanceMeters / 1000;
+          const price = km * KILOMETER_PRICE * 1.19; // including VAT
+          resolve({ distanceKm: km, price });
+        } else {
+          reject(new Error(status));
+        }
+      }
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- move price calculation to `calcLogic.js`
- show result after clicking *Strecke & Preis berechnen*
- call extracted logic in `BookingStepOne`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ccccced90832c8621c9c574a1a538